### PR TITLE
Fix evaluation.py call with existing log-name

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -26,7 +26,19 @@ def main():
     exe = os.path.join(env_path,"LinuxHeadless.x86_64")
     
     # Prepare the Unity log filename
-    log_fn = f"{args.log_name}_test.txt"
+
+    logs_dir = "./logfiles"
+    base_name = f"{args.log_name}_test"
+    ext = ".txt"
+    log_fn = base_name + ext
+    summary_path = os.path.join(logs_dir,log_fn)
+
+    counter = 1
+    while os.path.exists(summary_path):
+        log_fn = f"{base_name}_{counter}{ext}"
+        counter += 1
+        # Now summarize
+        summary_path = os.path.join(logs_dir,log_fn)
 
 
     sa = os.path.join(env_path,
@@ -45,10 +57,6 @@ def main():
     ]
     print("[EVAL] Running:", " ".join(cmd))
     subprocess.run(cmd, check=True)
-
-    # Now summarize
-    logs_dir = "./logfiles"
-    summary_path = os.path.join(logs_dir,log_fn)
 
     print(f"\n=== Evaluation Summary ({log_fn}) ===")
     summarize_log(str(summary_path))


### PR DESCRIPTION
**Problem**  
In `evaluation.py`, the log file name is provided via the required `--log-name` argument:  
```python
p.add_argument("--log-name", required=True,
               help="Base name for the output log file")
```          
When the script is run multiple times with the same `--log-name`, the latest `..._test.txt file` is not created, and the Evaluation Summary is always displayed from the first file generated.

**Solution**  
Added a loop to check whether `log-name_test.txt` already exists.
If it does, the log name is modified by appending a counter (e.g., `log-name{counter}_test.txt`) to ensure a new file is created on each run.